### PR TITLE
Setup instructions fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,26 +8,33 @@ This repository contains code which follows the [Design plan for database servic
 Install golang and make sure it is present in the environment $PATH:    
 Check ```go env``` to make sure everything is set.
   
-1. Get go-json-rest package
-
-```bash
-  go get -u github.com/omniscale/imposm3
-  go get -u github.com/mattn/go-sqlite3
+1. Get this package
+    ```bash
+  go get -u github.com/Greennav/service-database
 ```
 
-2. Fork the service-database repo and clone it to your $gopath/github.com/{username}/    
+2. Fork the service-database repo and add new remote to your local copy of package
+    ```bash
+  cd $GOPATH/src/github.com/Greennav/service-database
+  git remote add fork git@github.com:{GITHUB_USER}/service-database.git
+```   
+
 3. Go to the repository and run
-
-```
+    ```
   go build service-database.go
   ./database-service -i importer/monaco.osm.pbf -f test.db
   sqlite3 test.db
 ```
-
-```SQL
+    ```SQL
   sqlite> select count(*) from nodes;
   978
-```    
+```
+  
+4. Now you can push commits to your fork and then send PR
+    ```bash
+  git commit -a -m "Very important fix"
+  git push fork
+```  
   
 ## Current Status
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Check ```go env``` to make sure everything is set.
 2. Fork the service-database repo and add new remote to your local copy of package
     ```bash
   cd $GOPATH/src/github.com/Greennav/service-database
+  go get -u
   git remote add fork git@github.com:{GITHUB_USER}/service-database.git
 ```   
 


### PR DESCRIPTION
Hi.
If you try to make steps from setup instructions without doing "go get github.com/Greennav/service-database" you will get something like that:

```
➜  service-database git:(master) ✗ go build                    
database-service.go:9:2: cannot find package "github.com/GreenNav/service-database/database/sqlite" in any of:
    /usr/local/go/src/github.com/GreenNav/service-database/database/sqlite (from $GOROOT)
    /home/blide/go/src/github.com/GreenNav/service-database/database/sqlite (from $GOPATH)
database-service.go:10:2: cannot find package "github.com/GreenNav/service-database/importer" in any of:
    /usr/local/go/src/github.com/GreenNav/service-database/importer (from $GOROOT)
    /home/blide/go/src/github.com/GreenNav/service-database/importer (from $GOPATH)
```

It's because golang tries import "github.com/GreenNav/service-database", not "github.com/blide/service-database". Therefore, contribution guide was wrong.
