### PR TITLE
Added transaction cache limit and read methods

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -22,7 +22,15 @@ type OSMDatabase interface {
 	WriteRelationTags(Relations chan element.Relation) error
 	WriteRelationMembers(Relations chan element.Relation) error
 
-	GetEverythingWithinCoordinates(FromLong, FromLat, ToLong, ToLat int) (*OSMData, error)
+	ReadNode(Id int64) (node element.Node, err error)
+	ReadWay(Id int64) (way element.Way, err error)
+	ReadRelation(id int64) (relation element.Relation, err error)
+
+	ReadNodesByCoordinates(FromLat, FromLon, ToLat, ToLon float64) (nodes []element.Node, err error)
+	ReadWaysByCoordinates(FromLat, FromLon, ToLat, ToLon float64) (ways []element.Way, err error)
+	ReadRelationsByCoordinates() (relations []element.Member, err error)
+
+	ReadEverythingWithinCoordinates(FromLat, FromLon, ToLat, ToLon float64) (*OSMData, error)
 
 	NewTransaction() error
 	Commit() error

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -10,33 +10,31 @@ import (
 )
 
 const (
-	// CHANNELSIZE is used as size of the cache for nodes/ways/relations
+	CHANNELSIZE = 4 // CHANNELSIZE is used as size of the cache for nodes/ways/relations
 	// during conversion from pbf file to the database
-	CHANNELSIZE = 4
+
+	TRANSACTIONLIMIT = 300000 //Number of elements allowed in cache
+
+	NODES = iota //Element types
+	COORDS
+	WAYS
+	RELATIONS
 )
+
+type elementWriter struct {
+	element     interface{}
+	elementType int
+}
 
 // WriteToDatabase takes a pbf file and writes it to any database
 // that is conform to the database/OSMDatabase type
 func WriteToDatabase(PbfFileName string, Db database.OSMDatabase) error {
-	err := Db.NewTransaction()
-	if err != nil {
-		log.Fatal(err)
-	}
 	pbfCoords := make(chan []element.Node, CHANNELSIZE)
 	pbfNodes := make(chan []element.Node, CHANNELSIZE)
 	pbfWays := make(chan []element.Way, CHANNELSIZE)
 	pbfRelations := make(chan []element.Relation, CHANNELSIZE)
 
-	nodesToWrite := make(chan element.Node, CHANNELSIZE)
-	nodeTagsToWrite := make(chan element.Node, CHANNELSIZE)
-
-	waysToWrite := make(chan element.Way, CHANNELSIZE)
-	wayNodesToWrite := make(chan element.Way, CHANNELSIZE)
-	wayTagsToWrite := make(chan element.Way, CHANNELSIZE)
-
-	relationChannel := make(chan element.Relation, CHANNELSIZE)
-	relationTagsChannel := make(chan element.Relation, CHANNELSIZE)
-	relationMembersChannel := make(chan element.Relation, CHANNELSIZE)
+	writeManagerChannel := make(chan elementWriter, CHANNELSIZE)
 
 	pbfFile, err := pbf.Open(PbfFileName)
 	if err != nil {
@@ -44,69 +42,145 @@ func WriteToDatabase(PbfFileName string, Db database.OSMDatabase) error {
 	}
 
 	wg := sync.WaitGroup{}
+	writerWg := sync.WaitGroup{}
+
 	parser := pbf.NewParser(pbfFile, pbfCoords, pbfNodes, pbfWays, pbfRelations)
-
-	wg.Add(8)
-
-	go writeNodeHelper(Db.WriteNodes, nodesToWrite, "Nodes", &wg)
-	go writeNodeHelper(Db.WriteNodeTags, nodeTagsToWrite, "Node Tags", &wg)
-
-	go writeWayHelper(Db.WriteWays, waysToWrite, "Ways", &wg)
-	go writeWayHelper(Db.WriteWayTags, wayTagsToWrite, "Way Tags", &wg)
-	go writeWayHelper(Db.WriteWayNodes, wayNodesToWrite, "Way Nodes ", &wg)
-
-	go writeRelationHelper(Db.WriteRelation, relationChannel, "Relations", &wg)
-	go writeRelationHelper(Db.WriteRelationMembers, relationMembersChannel, "Relation Member", &wg)
-	go writeRelationHelper(Db.WriteRelationTags, relationTagsChannel, "Relation Tags", &wg)
+	wg.Add(4)
 
 	go func() {
+		var writer elementWriter
+		writer.elementType = COORDS
 		for nodes := range pbfCoords {
-			for _, node := range nodes {
-				nodesToWrite <- node
+			writer.element = nodes
+			writeManagerChannel <- writer
+		}
+		wg.Done()
+	}()
+	go func() {
+		var writer elementWriter
+		writer.elementType = NODES
+		for nodes := range pbfNodes {
+			writer.element = nodes
+			writeManagerChannel <- writer
+		}
+		wg.Done()
+	}()
+	go func() {
+		var writer elementWriter
+		writer.elementType = WAYS
+		for ways := range pbfWays {
+			writer.element = ways
+			writeManagerChannel <- writer
+		}
+		wg.Done()
+	}()
+	go func() {
+		var writer elementWriter
+		writer.elementType = RELATIONS
+		for relations := range pbfRelations {
+			writer.element = relations
+			writeManagerChannel <- writer
+		}
+		wg.Done()
+	}()
+	go func() {
+		wg.Wait()
+		close(writeManagerChannel)
+	}()
+
+	writerWg.Add(1)
+	go writeManager(Db, writeManagerChannel, &writerWg)
+	parser.Parse()
+	writerWg.Wait()
+	return nil
+}
+
+func writeManager(Db database.OSMDatabase, channel chan elementWriter, writerWg *sync.WaitGroup) {
+	for elementCount := 0; ; elementCount = 0 {
+		breakToExit := true
+		wg := sync.WaitGroup{}
+		err := Db.NewTransaction()
+		if err != nil {
+			log.Fatal(err)
+		}
+		nodesToWrite := make(chan element.Node, CHANNELSIZE)
+		nodeTagsToWrite := make(chan element.Node, CHANNELSIZE)
+
+		waysToWrite := make(chan element.Way, CHANNELSIZE)
+		wayNodesToWrite := make(chan element.Way, CHANNELSIZE)
+		wayTagsToWrite := make(chan element.Way, CHANNELSIZE)
+
+		relationChannel := make(chan element.Relation, CHANNELSIZE)
+		relationTagsChannel := make(chan element.Relation, CHANNELSIZE)
+		relationMembersChannel := make(chan element.Relation, CHANNELSIZE)
+
+		wg.Add(8)
+		go writeNodeHelper(Db.WriteNodes, nodesToWrite, "Nodes", &wg)
+		go writeNodeHelper(Db.WriteNodeTags, nodeTagsToWrite, "Node Tags", &wg)
+
+		go writeWayHelper(Db.WriteWays, waysToWrite, "Ways", &wg)
+		go writeWayHelper(Db.WriteWayTags, wayTagsToWrite, "Way Tags", &wg)
+		go writeWayHelper(Db.WriteWayNodes, wayNodesToWrite, "Way Nodes ", &wg)
+
+		go writeRelationHelper(Db.WriteRelation, relationChannel, "Relations", &wg)
+		go writeRelationHelper(Db.WriteRelationMembers, relationMembersChannel, "Relation Member", &wg)
+		go writeRelationHelper(Db.WriteRelationTags, relationTagsChannel, "Relation Tags", &wg)
+
+		for object := range channel {
+			switch object.elementType {
+			case COORDS:
+				nodes := object.element.([]element.Node)
+				for _, node := range nodes {
+					nodesToWrite <- node
+				}
+				elementCount += len(nodes)
+			case NODES:
+				nodes := object.element.([]element.Node)
+				for _, node := range nodes {
+					nodeTagsToWrite <- node
+				}
+				elementCount += len(nodes)
+			case WAYS:
+				ways := object.element.([]element.Way)
+				for _, way := range ways {
+					waysToWrite <- way
+					wayTagsToWrite <- way
+					wayNodesToWrite <- way
+				}
+				elementCount += len(ways)
+			case RELATIONS:
+				relations := object.element.([]element.Relation)
+				for _, relation := range relations {
+					relationChannel <- relation
+					relationTagsChannel <- relation
+					relationMembersChannel <- relation
+				}
+				elementCount += len(relations)
+			}
+			if elementCount >= TRANSACTIONLIMIT {
+				log.Println("writing at ", elementCount)
+				breakToExit = false
+				break
 			}
 		}
 		close(nodesToWrite)
-	}()
-	go func() {
-		for nodes := range pbfNodes {
-			for _, node := range nodes {
-				nodeTagsToWrite <- node
-			}
-		}
 		close(nodeTagsToWrite)
-	}()
-	go func() {
-		for ways := range pbfWays {
-			for _, way := range ways {
-				waysToWrite <- way
-				wayNodesToWrite <- way
-				wayTagsToWrite <- way
-			}
-		}
+		close(wayTagsToWrite)
 		close(waysToWrite)
 		close(wayNodesToWrite)
-		close(wayTagsToWrite)
-	}()
-	go func() {
-		for relations := range pbfRelations {
-			for _, relation := range relations {
-				relationChannel <- relation
-				relationMembersChannel <- relation
-				relationTagsChannel <- relation
-			}
-		}
+		close(relationTagsChannel)
 		close(relationChannel)
 		close(relationMembersChannel)
-		close(relationTagsChannel)
-	}()
-
-	parser.Parse()
-	wg.Wait()
-	if err := Db.Commit(); err != nil {
-		return err
+		wg.Wait()
+		err = Db.Commit()
+		if err != nil {
+			log.Println(err)
+		}
+		if breakToExit {
+			break
+		}
 	}
-
-	return nil
+	writerWg.Done()
 }
 
 func writeNodeHelper(function func(chan element.Node) error, channel chan element.Node, tag string, wg *sync.WaitGroup) {

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -1,6 +1,7 @@
 package importer_test
 
 import (
+	//"fmt"
 	"os"
 	"testing"
 
@@ -22,5 +23,12 @@ func TestWriteToSQLiteDatabase(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	/*osm, err := db.ReadEverythingWithinCoordinates(43.731341, 7.421213, 43.729883, 7.422897)
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Printf("Stats of ReadEverythingWithinCoordinates between 43.731341 N, 7.421213 E, 43.729883 N, 7.422897 E\n"+
+		"Nodes:%d\nWay:%d\n", len(osm.Nodes), len(osm.Ways))*/
+	db.Close()
 	os.Remove(TESTDATABASE)
 }


### PR DESCRIPTION
Hey,

Now import can run safely without crunching too much memory by holding everything in transaction cache, transaction limit can be changed according to the memory available on the machine. Imported Greater London PBF of size 44MB within 140secs and 130MB of memory, whereas earlier it memory consumed was around 350MB and took the same amount of time approx.

Added ReadEverything method which reads nodes and ways only, the query has to be reviewed. Also, can we store the tags and way_nodes as JSON in blob format which could help reduce the number.of reads drastically?

Thank you 
